### PR TITLE
feat: tiles properly update in DB when marking them

### DIFF
--- a/prisma/gameState.ts
+++ b/prisma/gameState.ts
@@ -1,5 +1,6 @@
 import { getInitialGameState } from "@games/app/games/tiktaktoe/entities/game";
 import prisma from "./prisma";
+import { Tile } from "@prisma/client";
 
 // READ
 export const getGameState = async () => {
@@ -33,4 +34,16 @@ export const createNewGame = async () => {
 
 export const deleteGameState = async () => {
   return await prisma.ticTacToe.deleteMany();
+}
+
+export const updateTile = async (tile: Tile) => {
+  const newTile = {...tile} as any;
+  delete newTile.id;
+
+  return await prisma.tile.update({
+    where: {
+      id: tile.id
+    },
+    data: newTile
+  });
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,6 @@ model Tile {
   marker      String     @default("")
   row         Int
   column      Int
-  TicTacToe   TicTacToe? @relation(fields: [ticTacToeId], references: [id])
+  ticTacToe   TicTacToe? @relation(fields: [ticTacToeId], references: [id])
   ticTacToeId String?    @db.ObjectId
 }

--- a/src/app/api/tictactoe/route.ts
+++ b/src/app/api/tictactoe/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
-import { createNewGame, deleteGameState, getGameState } from "../../../../prisma/gameState";
+import { createNewGame, deleteGameState, getGameState, updateTile } from "../../../../prisma/gameState";
+import { Tile } from "@prisma/client";
 
 export async function GET() {
     const gameState = await getGameState();
@@ -18,8 +19,9 @@ export async function POST() {
 }
 
 export async function PUT(request: Request) {
-    const res = await request.json();
-    console.log(JSON.stringify(res))
+    const updatedTile = await request.json() as Tile;
+    const savedGameState = await updateTile(updatedTile)
+    console.log(JSON.stringify(savedGameState))
 
-    return NextResponse.json(res);
+    return NextResponse.json(savedGameState);
 }

--- a/src/app/games/tiktaktoe/entities/tile.ts
+++ b/src/app/games/tiktaktoe/entities/tile.ts
@@ -1,0 +1,5 @@
+export type Tile = {
+	marker?: "X" | "O"
+	row: number;
+	column: number;
+}

--- a/src/app/games/tiktaktoe/entities/tile.ts
+++ b/src/app/games/tiktaktoe/entities/tile.ts
@@ -1,6 +1,0 @@
-
-export type Tile = {
-	marker?: "X" | "O"
-	row: number;
-	column: number;
-}

--- a/src/app/games/tiktaktoe/page.tsx
+++ b/src/app/games/tiktaktoe/page.tsx
@@ -18,15 +18,7 @@ export default async function Tiktaktoe() {
         {game?.tiles ? <DeleteGameState /> : null}
         {game ? (
           <div className={styles.board}>
-            <Tile />
-            <Tile />
-            <Tile />
-            <Tile />
-            <Tile />
-            <Tile />
-            <Tile />
-            <Tile />
-            <Tile />
+            {game.tiles.map((tile) => <Tile tile={tile} key={tile.id}/>)}
           </div>) : null}
 
         <div style={{color: 'white'}}>DB GAME STATE: {JSON.stringify(game)}</div>

--- a/src/app/games/tiktaktoe/tile.tsx
+++ b/src/app/games/tiktaktoe/tile.tsx
@@ -2,23 +2,24 @@
 import { useRouter } from "next/navigation";
 import styles from "./styles.module.css";
 import { useState, useTransition } from "react";
+import { Tile as TileType } from "@prisma/client";
 
-export default function Tile() {
-  const [marked, setMarked] = useState(false);
+export default function Tile({tile}: {tile: TileType}) {
+  const [marked, setMarked] = useState(tile.marker.length ? true : false);
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
 
   async function handleClick() {
-    setMarked(!marked);
+    const newMarkerState = !marked ? "X" : "";
+    const newTile: TileType = {...tile, marker: newMarkerState};
 
-    // TODO: send the needed db mutation here.
     await fetch('/api/tictactoe', {
       method: 'PUT',
-      body: JSON.stringify({
-        test: '123'
-      })
-    })
+      body: JSON.stringify(newTile)
+    });
+
+    setMarked(!marked);
 
     startTransition(() => {
       router.refresh();


### PR DESCRIPTION
With this PR, when clicking on a tile, it sends a PUT request to the server, which in turn updates the gamestate accordingly in the Database. Afterwards, a manual `router.refresh` is being executed, to refetch the new game state; this is admittedly a bit inefficient, but the only (and recommended) approach from next. See [here](https://beta.nextjs.org/docs/data-fetching/mutating).